### PR TITLE
Images in spotlight should have a max height

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -968,10 +968,11 @@ $baseurl: '{{ site.baseurl }}/images';
 			@include vendor('order', '1');
 			border-radius: 0;
 			width: 40%;
-
+			
 			img {
 				border-radius: 0;
 				width: 100%;
+				max-height: 300px;;
 			}
 		}
 


### PR DESCRIPTION
![](https://media0.giphy.com/media/erfnyCxPZacec/giphy.gif)